### PR TITLE
set real IP from X-Forwarded-For header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -43,6 +43,9 @@ http {
         server_name  _;
         root         /usr/share/nginx/html;
 
+        real_ip_header X-Forwarded-For;
+        set_real_ip_from 10.0.0.0/8;
+
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;
 


### PR DESCRIPTION
This change allows nginx to retrieve the real client IP from the X-Forwarded-For header set by the Openshift routers