### PR TITLE
Change nginx error_log level to warn

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,7 +2,7 @@
 #   * Official English Documentation: http://nginx.org/en/docs/
 
 worker_processes 1;
-error_log /dev/stdout info;
+error_log /dev/stdout warn;
 pid /run/nginx.pid;
 daemon off;
 


### PR DESCRIPTION
We should change the error_log level to warn. The info level is fairly verbose and shows information we don't particularly care about such as when keepalive connections are closed, timeouts...

`2017/06/12 20:55:46 [info] 24#0: *402112 client 10.130.0.1 closed keepalive connection (104: Connection reset by peer)`

The warn level is where is start being useful (warning, errors, etc...)