### PR TITLE
default route should be named openshift-io

### DIFF
--- a/openshift/www.openshift.io.app.yaml
+++ b/openshift/www.openshift.io.app.yaml
@@ -111,7 +111,7 @@ objects:
     creationTimestamp: null
     labels:
       service: wwwopenshiftio
-    name: www-openshift-io
+    name: openshift-io
   spec:
     host: ''
     port:


### PR DESCRIPTION
www-openshift-io is a downstream route that does a redirect.