### PR TITLE
Move index directive outside of location

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -43,6 +43,8 @@ http {
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;
 
+    index index.html
+
     # Load modular configuration files from the /etc/nginx/conf.d directory.
     # See http://nginx.org/en/docs/ngx_core_module.html#include
     # for more information.
@@ -57,11 +59,10 @@ http {
         include /etc/nginx/default.d/*.conf;
 
         location / {
-                index index.html
-                try_files $uri $uri/ @conbackend;
-                etag off;
-                if_modified_since off;
-                more_clear_headers 'Last-Modified';
+            try_files $uri $uri/ @conbackend;
+            etag off;
+            if_modified_since off;
+            more_clear_headers 'Last-Modified';
         }
 
         location /_openshiftio/ {


### PR DESCRIPTION
For some reason having index inside location
makes nginx treat the whole location as a local static
filesystem and ignore the proxy pass options
resulting in 405 Method not allowed on DELETE
instead of forwarding the request to the proxy pass.

Related to openshiftio/openshift.io#542