### PR TITLE
feat(chat): add Chat button to homepage

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -92,6 +92,9 @@
       <div class="content--row_3 learn-more">
         <a href="features.html">Learn more about the features <i class="fa fa-caret-right"></i></a>
       </div>
+      <div class="content--row_4 chat-mattermost">
+        <a href="https://chat.openshift.io/developers/channels/town-square" target="top" class="btn btn-bordered-blue"><i class="fa fa-comment"></i> Chat with us on MatterMost</a>
+      </div>
     </div>
     <div class="top-footer">
       <div></div>

--- a/src/assets/stylesheets/_layout.less
+++ b/src/assets/stylesheets/_layout.less
@@ -24,6 +24,10 @@ body {
   height: 150px;
   background-color: @color-pf-white;
 }
+.chat-mattermost {
+  height: 100px;
+  background-color: @color-pf-white;
+}
 .desktop-to-iphone {
   height: 50px;
   background: @color-pf-black-300;


### PR DESCRIPTION
Add a chat button to the homepage for easy access to the chat.openshift.io environment.

closes https://github.com/openshiftio/openshift.io/issues/1185

<img width="1904" alt="screen shot 2017-10-22 at 8 25 28 pm" src="https://user-images.githubusercontent.com/4032718/31868035-596451c0-b767-11e7-8fed-6fdd8ac161f3.png">
