### PR TITLE
fix(doc): Serve PDF files from documents folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,6 +129,19 @@ module.exports = {
           }
         ]
       },
+      // File loader for supporting documentation files (e.g. PDFs)
+      {
+        test: /\.pdf$/,
+        loaders: [
+          {
+            loader: "url-loader",
+            query: {
+              limit: 3000,
+              name: '/_openshiftio/assets/documents/[name].[ext]'
+            }
+          }
+        ]
+      },
       {
         test: /\.html$/,
         use: ['html-loader']


### PR DESCRIPTION
This is in support of issue #1392 . Requests for PDF files under URL https://openshift.io/_openshiftio/assets/documents will be handled provided the requested PDF file exists in `/src/assets/documents`. Note that PR #1396 is not fixed by this PR; #1396 has the `osiogettingstarted.pdf` document in the root folder; it would need to be moved to `/src/assets/documents` (a folder which does not yet exist, btw).

This matches the pattern for how other content is currently being served, but since this will be a URL which is shared and more visible to users, we probably want to consider a better method for exposing 'public' files such as this. https://openshift.io/_openshiftio/assets/documents/osiogettingstarted.pdf does not generate a lot of confidence, as far as URLs go. It would be better (and I'm not saying this is even possible) if we could designate a magic folder (e.g. call it `/src/assets/magic`) such that a file `/src/assets/magic/name.ext` gets served via URL https://openshift.io/name.ext. As an alternative, maybe a URL such as https://openshift.io/content/name.ext. 

I was tempted to change the `name:` param in my commit to get a better public URL, but I just wasn't confident that wouldn't break anything else. So I stuck with a copy/paste methodology to get something working. But if

```javascript
    name: '/documents/[name].[ext]'
```

would at least elevate the PDFs in `/src/assets/documents` to URL https://openshift.io/documents safely, then I'd prefer to go that route. (pun intended?)
