### PR TITLE
fox(doc): Serve getting started PDF document from root

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,6 +129,19 @@ module.exports = {
           }
         ]
       },
+      // File loader for supporting documentation files (e.g. PDFs)
+      {
+        test: /\.pdf$/,
+        loaders: [
+          {
+            loader: "url-loader",
+            query: {
+              limit: 3000,
+              name: '/_openshiftio/assets/documents/[name].[ext]'
+            }
+          }
+        ]
+      },
       {
         test: /\.html$/,
         use: ['html-loader']

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,11 @@ if (isProd) {
       from: 'manifest.json',
       to: '_openshiftio/',
       toType: 'dir'
+    },
+    {
+      from: 'src/assets/documents',
+      to: '',
+      toType: 'dir'
     }
   ]);
 } else {
@@ -45,6 +50,11 @@ if (isProd) {
     {
       from: 'manifest.json',
       to: '_openshiftio/',
+      toType: 'dir'
+    },
+    {
+      from: 'src/assets/documents',
+      to: '',
       toType: 'dir'
     }
   ]);
@@ -134,14 +144,14 @@ module.exports = {
         test: /\.pdf$/,
         loaders: [
           {
-            loader: "url-loader",
-            query: {
-              limit: 3000,
+            loader: "file-loader",
+            options: {
               name: '/_openshiftio/assets/documents/[name].[ext]'
             }
           }
         ]
       },
+      
       {
         test: /\.html$/,
         use: ['html-loader']


### PR DESCRIPTION
This change permits the serving of any PDF files found in /src/assets/documents via a URL directly from the root of the application.

e.g. /src/assets/documents/foo.pdf is available via https://openshift.io/foo.pdf

I also moved osiogettingstarted.pdf to the new documents directory, to resolve issue #1392 