### PR TITLE
fix(redirect): redirect after response complete

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -192,42 +192,48 @@ export class Auth {
     return result;
   }
 
- updateUserMenu() {
-    if (this.authToken) {
-      this.getUser(this.authToken, (response: any) => {
-        let user = response.data;
-        if (user.attributes.imageURL) {
-          $("#userImage")
-            .attr("src", user.attributes.imageURL)
-            .removeClass("hidden");
+ updateUserMenu() : Promise<any> {
+    return new Promise((resolve, reject) => {
+        if (this.authToken) {
+          this.getUser(this.authToken, (response: any) => {
+            let user = response.data;
+            if (user.attributes.imageURL) {
+              $("#userImage")
+                .attr("src", user.attributes.imageURL)
+                .removeClass("hidden");
+            } else {
+              $("#noUserImage").removeClass("hidden");
+            }
+            $("#userName").html(user.attributes.fullName);
+            $("#profileLink").attr("href", "/" + user.attributes.username);
+            $("#hideLogIn").hide();
+            $("#hideSignUp").hide();
+            $("#loggedInUserName").removeClass('hidden');
+            $("#logoutAction").removeClass('hidden');
+
+            resolve();
+            
+          },
+            (response: JQueryXHR, textStatus: string, errorThrown: string) => {
+              if (response.status == 401) {
+                this.refreshToken();
+              } else {
+                this.logout();
+              }
+            }
+          );
         } else {
-          $("#noUserImage").removeClass("hidden");
+          $("#hideLogIn").show();
+          $("#hideSignUp").show();
+          $("#loggedInUserName").hide();
+          $("#logoutAction").hide();
         }
-        $("#userName").html(user.attributes.fullName);
-        $("#profileLink").attr("href", "/" + user.attributes.username);
-        $("#hideLogIn").hide();
-        $("#hideSignUp").hide();
-        $("#loggedInUserName").removeClass('hidden');
-        $("#logoutAction").removeClass('hidden');
+      });
+  }
 
-        // Start redirect only after response from user is complete.
-        window.location.href = `/_gettingstarted`;
-
-      },
-        (response: JQueryXHR, textStatus: string, errorThrown: string) => {
-          if (response.status == 401) {
-            this.refreshToken();
-          } else {
-            this.logout();
-          }
-        }
-      );
-    } else {
-      $("#hideLogIn").show();
-      $("#hideSignUp").show();
-      $("#loggedInUserName").hide();
-      $("#logoutAction").hide();
-    }
+  redirectToGettingStarted(){
+    window.location.href= `/_gettingstarted`;
+    return true;
   }
 
   handleError(url: uri.URI) {
@@ -365,7 +371,7 @@ $(document)
     let auth = new Auth(analytics);
     auth.handleLogin(url);
     auth.handleError(url);
-    auth.updateUserMenu();
+    auth.updateUserMenu().then(auth.redirectToGettingStarted);
     auth.bindLoginLogout();
   });
 

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -178,7 +178,6 @@ export class Auth {
 
   bindLoggedInUser() {
     this.loggedIn = true;
-    this.updateUserMenu();
     $("#loggedInUserName").show();
     $("#logoutAction").show();
   }
@@ -211,10 +210,8 @@ export class Auth {
         $("#loggedInUserName").removeClass('hidden');
         $("#logoutAction").removeClass('hidden');
 
-        // Start redirect only after response from user returns.
-        //setTimeout(function () {
-          window.location.href = `/_gettingstarted`;
-        //}, 1000);
+        // Start redirect only after response from user is complete.
+        window.location.href = `/_gettingstarted`;
 
       },
         (response: JQueryXHR, textStatus: string, errorThrown: string) => {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -172,9 +172,6 @@ export class Auth {
       // Clear the tokens from the URL, they are toooo long
       history.pushState(null, "", location.href.split("?")[0]);
       // Put a short delay here, as local storage takes a few MS to update
-      setTimeout(function () {
-        window.location.href = `/_gettingstarted`;
-      }, 1000);
       return;
     }
   }
@@ -213,6 +210,12 @@ export class Auth {
         $("#hideSignUp").hide();
         $("#loggedInUserName").removeClass('hidden');
         $("#logoutAction").removeClass('hidden');
+
+        // Start redirect only after response from user returns.
+        //setTimeout(function () {
+          window.location.href = `/_gettingstarted`;
+        //}, 1000);
+
       },
         (response: JQueryXHR, textStatus: string, errorThrown: string) => {
           if (response.status == 401) {


### PR DESCRIPTION
1. Redirect UI to `GettingStarted` page only if `/api/user` request is complete.
Otherwise the `/api/user` request gets cancelled , which calls a `.logout()`.

2. Avoid calling `updateUserMenu()` inside `bindLoggedInUser()` because it always gets called anyway in `document.ready(..)`. Calling it twice again causes  two `/api/user` requests where one of them gets cancelled causing the same problem as (1)

more: https://github.com/openshiftio/openshift.io/issues/1402#issuecomment-345595930

fixes https://github.com/openshiftio/openshift.io/issues/1402