### PR TITLE
fix(layout): Update browser support

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -37,7 +37,8 @@
       "rem",
       "vh",
       "vw",
-      "fr"
+      "fr",
+      "dpcm"
     ],
     "value-list-comma-space-after": "always-single-line",
     "value-list-comma-space-before": "never",

--- a/src/app/pages/get-involved.html
+++ b/src/app/pages/get-involved.html
@@ -122,26 +122,6 @@
         </div>
         <div></div>
       </div>
-      <!-- <div class="content--row_contribute content--row_contribute-stack-overflow">
-        <div></div>
-        <div>
-          <h2 class="content--row_contribute-stack-overflow-heading">
-            <div>
-              <i class="fa fa-stack-overflow fa-2x"></i>
-              STACK OVERFLOW
-            </div>
-            <div class="horizontal-line">
-            </div>
-          </h2>
-          <p>
-            Explore the channel(s) for any unanswered questions and community support.
-          </p>
-          <p>
-            <a href="https://www.stackoverflow.com" target="top" class="action-links">Explore <i class="fa fa-caret-right"></i></a>
-          </p>
-        </div>
-        <div></div>
-      </div> -->
       <div class="content--row_contribute content--row_contribute-chat">
         <div></div>
         <div>

--- a/src/assets/stylesheets/_flex.less
+++ b/src/assets/stylesheets/_flex.less
@@ -1,0 +1,338 @@
+.grid-container {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -moz-flex;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-justify-content: space-around;
+  justify-content: space-around;
+  -webkit-flex-flow: row wrap;
+  flex-flow: row wrap;
+  -webkit-align-items: stretch;
+  align-items: stretch;
+  height: 100vh;
+}
+.grid-container--features {
+  &:extend(.grid-container);
+  grid-template-rows: 70px auto auto auto;
+}
+.grid-container--not-authorized {
+  &:extend(.grid-container);
+  grid-template-rows: 70px auto;
+  grid-template-areas:
+    'header header header'
+    'content content content';
+}
+.header,
+.content,
+.top-footer,
+.bottom-footer {
+  flex: 1 100%;
+}
+.register {
+  display: table;
+}
+.content {
+  width: 100%;
+  padding-top: 70px;
+}
+.content--row_1 {
+  display: inline-inline-flex;
+  margin: 0 auto;
+  width: 100%;
+  div:nth-of-type(1) {
+    flex: 1;
+  }
+  div:nth-of-type(2) {
+    flex: 2;
+  }
+  div:nth-of-type(3) {
+    flex: 1;
+  }
+  &.register {
+    display: table;
+  }
+}
+.content--row_dashboard {
+  display: inline-flex;
+  > div {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+  div:nth-of-type(1) {
+    flex: 1;
+  }
+  div:nth-of-type(2) {
+    flex: 2;
+  }
+  div:nth-of-type(3) {
+    flex: 2;
+  }
+  div:nth-of-type(4) {
+    flex: 1;
+  }
+  @media screen and (max-width: 768px) {
+    margin-left: 10px;
+    margin-right: 10px;
+    grid-template-columns: 12fr;
+    div:nth-of-type(1) {
+      order: 1;
+    }
+    div:nth-of-type(2) {
+      order: 3;
+    }
+    div:nth-of-type(3) {
+      order: 2;
+    }
+    div:nth-of-type(4) {
+      order: 4;
+    }
+  }
+}
+.content--row_analytics {
+  display: inline-flex;
+  > div {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+  div:nth-of-type(1) {
+    flex: 1;
+  }
+  div:nth-of-type(2) {
+    flex: 2;
+  }
+  div:nth-of-type(3) {
+    flex: 2;
+  }
+  div:nth-of-type(4) {
+    flex: 1;
+  }
+  @media screen and (max-width: 768px) {
+    margin-left: 10px;
+    margin-right: 10px;
+    grid-template-columns: 12fr;
+    div:nth-of-type(1) {
+      order: 1;
+    }
+    div:nth-of-type(2) {
+      order: 2;
+    }
+    div:nth-of-type(3) {
+      order: 3;
+    }
+    div:nth-of-type(4) {
+      order: 4;
+    }
+  }
+}
+.content--row_pipelines {
+  display: inline-flex;
+  div:nth-of-type(1) {
+    flex: 1;
+  }
+  div:nth-of-type(2) {
+    flex: 2;
+  }
+  div:nth-of-type(3) {
+    flex: 2;
+  }
+  div:nth-of-type(4) {
+    flex: 1;
+  }
+  > div {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+  @media screen and (max-width: 768px) {
+    margin-left: 10px;
+    margin-right: 10px;
+    grid-template-columns: 12fr;
+    div:nth-of-type(1) {
+      order: 1;
+    }
+    div:nth-of-type(2) {
+      order: 3;
+    }
+    div:nth-of-type(3) {
+      order: 2;
+    }
+    div:nth-of-type(4) {
+      order: 4;
+    }
+  }
+}
+.content--row_planning {
+  display: inline-flex;
+  div:nth-of-type(1) {
+    flex: 1;
+  }
+  div:nth-of-type(2) {
+    flex: 2;
+  }
+  div:nth-of-type(3) {
+    flex: 2;
+  }
+  div:nth-of-type(4) {
+    flex: 1;
+  }
+  > div {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+  @media screen and (max-width: 768px) {
+    margin-left: 10px;
+    margin-right: 10px;
+    div:nth-of-type(1) {
+      order: 1;
+    }
+    div:nth-of-type(2) {
+      order: 2;
+    }
+    div:nth-of-type(3) {
+      order: 3;
+    }
+    div:nth-of-type(4) {
+      order: 4;
+    }
+  }
+}
+.content--row_contribute {
+  display: inline-flex;
+  width: 100%;
+  > div:nth-of-type(1) {
+    width: 10px;
+  }
+  > div:nth-of-type(2) {
+    flex: 2;
+    flex-grow: 2;
+  }
+  > div {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+}
+.content--row_contribute-banner {
+  grid-row: 1;
+  padding-top: 0;
+}
+.content--row_contribute-get-started {
+  padding-top: 25px;
+}
+.content--row_contribute-reporting {
+  &-heading {
+    div:first-of-type {
+      margin-right: 50px;
+    }
+  }
+}
+.content--row_contribute-chat {
+  &-heading {
+    div:first-of-type {
+      margin-right: 50px;
+    }
+  }
+}
+.content--row_contribute-email {
+  &-heading {
+    div:first-of-type {
+      margin-right: 50px;
+    }
+  }
+}
+.content--row_contribute-faq {
+  &-heading {
+    div:first-of-type {
+      margin-right: 50px;
+    }
+  }
+}
+.content--row_contribute-news {
+  &-heading {
+    div:first-of-type {
+      margin-right: 50px;
+    }
+  }
+  .news-links {
+    display: inline-flex;
+    > div {
+      flex: 1;
+    }
+  }
+}
+.content--row_contribute-github {
+  &-heading {
+    div:first-of-type {
+      margin-right: 50px;
+    }
+  }
+}
+.content--row_contribute-upstream {
+  .padding--bottom_grid;
+  > div:nth-of-type(2) {
+    .upstream-links {
+      flex-wrap: wrap;
+      justify-content: space-around;
+    }
+  }
+  &-heading {
+    div:first-of-type {
+      margin-right: 50px;
+    }
+  }
+}
+.news-links {
+  margin-top: 15px;
+}
+.github-links {
+  margin-top: 15px;
+}
+.upstream-links {
+  margin-top: 15px;
+  // @media screen and (max-width: 768px) {
+  //   grid-template-columns: 55px 1fr;
+  // }
+}
+.top-footer {
+  display: inline-flex;
+  > div {
+    flex: 1;
+  }
+  margin: 0 auto;
+  @media screen and (max-width: 768px) {
+    grid-template-columns: 12fr;
+    height: 100%;
+    div:nth-of-type(1) {
+      order: 1;
+    }
+    div:nth-of-type(2) {
+      order: 3;
+    }
+    div:nth-of-type(3) {
+      order: 4;
+    }
+    div:nth-of-type(4) {
+      order: 5;
+    }
+    div:nth-of-type(5) {
+      order: 2;
+    }
+    div:nth-of-type(6) {
+      order: 6;
+    }
+  }
+}
+.bottom-footer {
+  margin: 0 auto;
+  display: inline-flex;
+  > div:nth-of-type(1) {
+    flex: 1;
+    text-align: center;
+  }
+  > div:nth-of-type(2) {
+    flex: 2;
+  }
+  @media screen and (max-width: 768px) {
+    //
+  }
+}

--- a/src/assets/stylesheets/_footer.less
+++ b/src/assets/stylesheets/_footer.less
@@ -33,7 +33,9 @@
   width: 100%;
   background-color: @color-rh-black-900;
   font-size: 12px;
-  height: 100%;
+  @media screen and (max-width: 768px) {
+    height: 100%;
+  }
   &--item {
     margin: 0 auto;
     @media (min-width: 320px) and (max-width: 996px) { margin: 0; }

--- a/src/assets/stylesheets/_layout.less
+++ b/src/assets/stylesheets/_layout.less
@@ -1,10 +1,10 @@
 body {
-  font-family: 'Overpass', sans-serif;
+  font-family: Overpass, sans-serif;
   font-size: @font-size-base;
 }
 .header {
   background-color: @color-rh-black-800;
-  padding: 20px;
+  padding: 35px;
 }
 .content { background-color: @color-pf-white; }
 .bottom-footer { min-height: 60px; }
@@ -50,6 +50,8 @@ body {
   z-index: 1;
 }
 .register {
+  padding-top: 70px;
+  margin-top: -70px;
   min-height: 675px;
   width: 100%;
   background: url('../images/background_register.png') #ddd no-repeat;
@@ -60,6 +62,8 @@ body {
 }
 .content--row_contribute {
   &-banner {
+    padding-top: 70px;
+    margin-top: -70px;
     min-height: 420px;
     width: 100%;
     background: url('../images/banner_contribute@3x.png') @color-rh-black-800 no-repeat;
@@ -96,6 +100,9 @@ body {
   }
   .horizontal-line {
     &:after {
+      @media all and (-webkit-min-device-pixel-ratio:0) and (min-resolution: .001dpcm) {
+        display: none;
+      }
       display: inline-block;
       content: '';
       width: 100%;
@@ -112,6 +119,8 @@ body {
   }
 }
 .video {
+  padding-top: 70px;
+  margin-top: -70px;
   min-height: 450px;
   width: 100%;
   text-align: center;

--- a/src/assets/stylesheets/osio.less
+++ b/src/assets/stylesheets/osio.less
@@ -4,6 +4,7 @@
 @import (reference) '../../../node_modules/patternfly/src/less/patternfly.less';
 
 // layout
+@import '_flex.less';
 @import '_grid.less';
 
 @import '_colors.less';


### PR DESCRIPTION
Update layout to support older browsers that cannot render CSS Grid. Utilize flexbox as a fallback display property.

fixes https://github.com/fabric8-ui/fabric8-ux/issues/840
related to https://github.com/openshiftio/openshift.io/issues/2050