### PR TITLE
feat(docs): Add Documentation page with links

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -44,6 +44,9 @@
               <li>
                 <a href="get-involved.html" class="navbar-nav-links--contribute uppercase" aria-label="GetInvolved">Get Involved</a>
               </li>
+              <li>
+                <a href="documentation.html" class="navbar-nav-links--documentation uppercase" aria-label="Documentation">Documentation</a>
+              </li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
               <li id="loggedInUserName" class="navbar-nav--user">
@@ -119,6 +122,9 @@
           </li>
           <li>
             <a href="get-involved.html" aria-label="Get Involved">Get Involved</a>
+          </li>
+          <li>
+            <a href="documentation.html" aria-label="Documentation">Documentation</a>
           </li>
         </ul>
       </div>

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -192,6 +192,7 @@ export class Auth {
         // check to see if user is on root and logged in successfully - if so, move them to gettingstarted
         if (window.location.pathname.indexOf('get-involved') === -1 &&
             window.location.pathname.indexOf('features')  === -1 &&
+            window.location.pathname.indexOf('documentation')  === -1 &&
             window.location.pathname.indexOf('not-authorized') === -1) {
           setTimeout(function () {
                 window.location.href = `/_gettingstarted`;

--- a/src/app/pages/documentation.html
+++ b/src/app/pages/documentation.html
@@ -85,96 +85,18 @@
       </nav>
     </div>
     <div class="content">
-      <div class="content--row_1 video">
-        <div></div>
-        <div class="video--content">
-          <h1 class="uppercase">See OpenShift.io in Action</h1>
-          <div class="video--content_container">
-            <iframe title="OpenShift.io Introduction" width="560" height="315" src="https://www.youtube.com/embed/XNdi4AC_EPQ?rel=0" frameborder="0" allowfullscreen></iframe>
-          </div>
-        </div>
-        <div></div>
-      </div>
-      <div class="content--row_dashboard">
+      <div class="content--row_documentation">
         <div></div>
         <div>
-          <img src="../../assets/images/screencap_home.png" alt="Dashboard Screenshot" width="100%" />
-        </div>
-        <div>
-          <h2>WHAT IS OPENSHIFT.IO (OSIO)?</h2>
-          <p>
-            OpenShift.io, combined with OpenShift Online, provides an integrated approach to DevOps, including all the tools a team needs to analyze, plan, create and deploy services.
-          </p>
-          <p>
-            <ul>
-              <li>One-click Linux container management</li>
-              <li>Machine learning system</li>
-              <li>Open Source</li>
-              <li>Incorporate many projects like fabric8 and Eclipse Che</li>
-            </ul>
-          </p>
-        </div>
-        <div></div>
-      </div>
-      <div class="content--row_analytics">
-        <div></div>
-        <div>
-          <h2>ALLOW DEVELOPMENT TEAMS TO MAKE MORE CONFIDENT TECHNOLOGY DECISIONS</h2>
-          <p>
-            OpenShift.io helps developers make better decisions; it provides actionable recommendations and insights around the software components developers use.
-          </p>
-          <p>
-            <ul>
-              <li>OpenShift.io Analytics applies machine learning algorithms based on usage patterns of components</li>
-              <li>Data is gathered from public sources like Github and Maven</li>
-              <li>Get tangible information for credible decision-making</li>
-            </ul>
-          </p>
-        </div>
-        <div>
-          <img src="../../assets/images/screencap_stack_report.png" alt="Analytics" width="100%" />
-        </div>
-        <div></div>
-      </div>
-      <div class="content--row_pipelines">
-        <div></div>
-        <div>
-          <img src="../../assets/images/screencap_pipeline_complete.png" alt="Pipelines" width="100%" />
-        </div>
-        <div>
-          <h2>SIMPLE TO CREATE CONTAINERIZED DEV, TEST AND STAGING ENVIRONMENTS</h2>
-          <p>
-            Developers can automatically create containerized development environments with the workspace management capabilities of Eclipse Che.
-          </p>
-          <p>
-            <ul>
-              <li>OSIO creates environments hosted on OpenShift Online</li>
-              <li>Integrates the Jenkins Pipeline plugins</li>
-              <li>Create simplest ‘just build it’ pipeline or add promotions</li>
-              <li>Pipeline definitions written using a Groovy DSL</li>
-            </ul>
-          </p>
-        </div>
-        <div></div>
-      </div>
-      <div class="content--row_planning">
-        <div></div>
-        <div>
-          <h2>MINIMIZE TIME &amp; EFFORT TO BUILD AND MAINTAIN A DEVELOPMENT TOOL CHAIN</h2>
-          <p>
-            OpenShift.io is a hosted service with planning tools like prioritizable backlogs and kanban boards for managing your work.
-          </p>
-          <p>
-            <ul>
-              <li>Coding, editing, debugging tools on <a href="http://www.eclipse.org/che/" target="top">Eclipse Che</a></li>
-              <li>Dashboard and reporting tools</li>
-              <li>Integrated tools that share a common datastore</li>
-              <li>Tools reduces building and maintenance efforts</li>
-            </ul>
-          </p>
-        </div>
-        <div>
-          <img src="../../assets/images/screencap_che.png" alt="Planner" width="100%" />
+          <h1 class="text-center">Red Hat OpenShift.io Documentation</h1>
+          <ul>
+            <li>
+              <a href="https://docs.openshift.io/getting-started-guide.html">OpenShift.io Getting Started Guide</a> <a href="https://docs.openshift.io/getting-started-guide.pdf">(PDF)</a>
+            </li>
+            <li>
+              <a href="https://docs.openshift.io/user-guide.html">OpenShift.io User Guide</a> <a href="https://docs.openshift.io/user-guide.pdf">(PDF)</a>
+            </li>
+          </ul>
         </div>
         <div></div>
       </div>

--- a/src/app/pages/get-involved.html
+++ b/src/app/pages/get-involved.html
@@ -45,6 +45,9 @@
               <li>
                 <a href="get-involved.html" class="navbar-nav-links--contribute uppercase" aria-label="GetInvolved">Get Involved</a>
               </li>
+              <li>
+                <a href="documentation.html" class="navbar-nav-links--documentation uppercase" aria-label="Documentation">Documentation</a>
+              </li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
               <li id="loggedInUserName" class="navbar-nav--user">
@@ -345,6 +348,9 @@
           </li>
           <li>
             <a href="get-involved.html" aria-label="Get Involved">Get Involved</a>
+          </li>
+          <li>
+            <a href="documentation.html" aria-label="Documentation">Documentation</a>
           </li>
         </ul>
       </div>

--- a/src/app/pages/not-authorized.html
+++ b/src/app/pages/not-authorized.html
@@ -45,6 +45,9 @@
               <li>
                 <a href="get-involved.html" class="navbar-nav-links--contribute uppercase" aria-label="GetInvolved">Get Involved</a>
               </li>
+              <li>
+                <a href="documentation.html" class="navbar-nav-links--documentation uppercase" aria-label="Documentation">Documentation</a>
+              </li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
               <li id="loggedInUserName" class="navbar-nav--user">

--- a/src/assets/stylesheets/_grid.less
+++ b/src/assets/stylesheets/_grid.less
@@ -52,6 +52,11 @@
 .content--row_5 {
   grid-row: 5;
 }
+.content--row_documentation {
+  display: grid;
+  grid-template-columns: 1fr 10fr 1fr;
+  height: 90vh;
+}
 .content--row_dashboard {
   margin: 0 auto;
   display: grid;

--- a/src/assets/stylesheets/_navigation.less
+++ b/src/assets/stylesheets/_navigation.less
@@ -93,7 +93,6 @@
   font-size: @font-size-base;
   &-links--features {
     margin-left: 70px;
-    margin-right: 30px;
   }
   .navbar-nav--user {
     margin-top: 10px;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,7 +151,7 @@ module.exports = {
           }
         ]
       },
-      
+
       {
         test: /\.html$/,
         use: ['html-loader']
@@ -191,6 +191,12 @@ module.exports = {
     new HtmlWebpackPlugin({
       filename: 'not-authorized.html',
       template: 'src/app/pages/not-authorized.html',
+      chunks: ['app'],
+      chunksSortMode: 'dependency'
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'documentation.html',
+      template: 'src/app/pages/documentation.html',
       chunks: ['app'],
       chunksSortMode: 'dependency'
     }),


### PR DESCRIPTION
Add a Documentation page with link to OpenShift.io Getting Started and User Guides.

<img width="1564" alt="screen shot 2018-02-15 at 2 08 07 pm" src="https://user-images.githubusercontent.com/4032718/36275752-aee48384-1259-11e8-9e13-438ad3678eb9.png">
