### PR TITLE
home page update March 23

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -87,13 +87,12 @@
       <div class="content--row_1 register">
         <div></div>
         <div class="register--content">
-          <h1>INTRODUCING OPENSHIFT.IO</h1>
+          <h1>WELCOME TO OPENSHIFT.IO</h1>
           <p class="introduction-text">
             OpenShift.io is an open online development environment for planning, creating and deploying hybrid cloud services.
           </p>
-          <a class="btn btn-heavy-cta btn-lg beta-submit uppercase" role="button" id="registerContent">sign up for the preview</a>
+          <a class="btn btn-heavy-cta btn-lg beta-submit uppercase" role="button" id="registerContent">sign up today</a>
           <div class="help-block">
-            Currently waitlisting registrants.
           </div>
         </div>
         <div></div>

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -92,8 +92,6 @@
             OpenShift.io is an open online development environment for planning, creating and deploying hybrid cloud services.
           </p>
           <a class="btn btn-heavy-cta btn-lg beta-submit uppercase" role="button" id="registerContent">sign up today</a>
-          <div class="help-block">
-          </div>
         </div>
         <div></div>
       </div>


### PR DESCRIPTION
3 changes to align with the state of the site:  

Changed title from "Introducing" to "Welcome to OpenShift.io". 
Changed CTA button from "Sign up for the Preview" to "sign up today". 
Removed the line "Currently waitlisting registrants."