### PR TITLE
fix(template): Create a UX Issue Template

### DIFF
--- a/.github/uxd_template.md
+++ b/.github/uxd_template.md
@@ -1,0 +1,10 @@
+## UXD Issue Template - fill out all sections
+
+### Description
+Add a description of the issue that you are creating. Be as descriptive as possible, sharing any information that is relevant to the issue.
+
+### Parent Issue(s)
+- [past link here]() or None
+
+### Verification Criteria
+- [ ]


### PR DESCRIPTION
Create a UX Issue Template for UXD to utilize when creating new Issues.

The URL for creating the template will be https://github.com/openshiftio/openshift.io/issues/new?template=uxd_template.md

This also creates a default (and blank) issue template from with any interaction with 'New Issue' will use by default.

Related to https://github.com/openshiftio/openshift.io/issues/2880