### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/fabric8-openshift-nginx:latest
+FROM quay.io/openshiftio/rhel-base-fabric8-openshift-nginx:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-REGISTRY="push.registry.devshift.net"
+REGISTRY="quay.io"
 DEPLOY_CONT="wwwopenshiftio-deploy"
 BUILDER_CONT="wwwopenshiftio-builder"
 
 if [ "$TARGET" = "rhel" ]; then
   DOCKERFILE_DEPLOY="Dockerfile.deploy.rhel"
-  REGISTRY_URL=${REGISTRY}/osio-prod/fabric8io/wwwopenshiftio
+  REGISTRY_URL=${REGISTRY}/openshiftio/rhel-fabric8io-wwwopenshiftio
 else
   DOCKERFILE_DEPLOY="Dockerfile.deploy"
-  REGISTRY_URL=${REGISTRY}/fabric8io/wwwopenshiftio
+  REGISTRY_URL=${REGISTRY}/openshiftio/fabric8io-wwwopenshiftio
 fi
 
 # Show command before executing
@@ -20,10 +20,13 @@ set -e
 
 # Export needed vars
 set +x
-for var in BUILD_NUMBER BUILD_URL GIT_COMMIT DEVSHIFT_USERNAME DEVSHIFT_PASSWORD DEVSHIFT_TAG_LEN; do
-  export $(grep ${var} jenkins-env | xargs)
-done
-export BUILD_TIMESTAMP=`date -u +%Y-%m-%dT%H:%M:%S`+00:00
+eval "$(./env-toolkit load -f jenkins-env.json \
+            BUILD_NUMBER \
+            BUILD_URL \
+            GIT_COMMIT \
+            QUAY_USERNAME \
+            QUAY_PASSWORD \
+            DEVSHIFT_TAG_LEN)"
 set -x
 
 # We need to disable selinux for now, XXX
@@ -34,24 +37,31 @@ yum -y install docker
 yum clean all
 service docker start
 
-# Build builder image
-docker build -t "${BUILDER_CONT}" -f Dockerfile.builder .
+if [ ! -d dist ]; then
+    mkdir dist
 
-# Clean builder container
-docker ps | grep -q "${BUILDER_CONT}" && docker stop "${BUILDER_CONT}"
-docker ps -a | grep -q "${BUILDER_CONT}" && docker rm "${BUILDER_CONT}"
+    # Build builder image
+    docker build -t "${BUILDER_CONT}" -f Dockerfile.builder .
 
-mkdir -p dist && docker run --detach=true --name="${BUILDER_CONT}" -t -v $(pwd)/dist:/dist:Z -e BUILD_NUMBER -e BUILD_URL -e BUILD_TIMESTAMP "${BUILDER_CONT}"
+    # Clean builder container
+    docker ps | grep -q "${BUILDER_CONT}" && docker stop "${BUILDER_CONT}"
+    docker ps -a | grep -q "${BUILDER_CONT}" && docker rm "${BUILDER_CONT}"
+    docker run --detach=true --name="${BUILDER_CONT}" -t \
+        -v $(pwd)/dist:/dist:Z \
+        -e BUILD_NUMBER -e BUILD_URL -e BUILD_TIMESTAMP \
+        "${BUILDER_CONT}"
 
-# Build almigty-ui
-docker exec "${BUILDER_CONT}" npm install
-docker exec "${BUILDER_CONT}" npm run build:prod
-docker exec -u root "${BUILDER_CONT}" cp -r /home/fabric8/wwwopenshiftio/dist /
+    # Build almigty-ui
+    docker exec "${BUILDER_CONT}" npm install
+    docker exec "${BUILDER_CONT}" npm run build:prod
+    docker exec -u root "${BUILDER_CONT}" cp -r /home/fabric8/wwwopenshiftio/dist /
+fi
 
-if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-  docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+  docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${REGISTRY}
 else
   echo "Could not login, missing credentials for the registry"
+  exit 1
 fi
 
 docker build -t "${DEPLOY_CONT}" -f "${DOCKERFILE_DEPLOY}" .

--- a/openshift/www.openshift.io.app.yaml
+++ b/openshift/www.openshift.io.app.yaml
@@ -124,6 +124,6 @@ objects:
   status: {}
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/fabric8io/wwwopenshiftio
+  value: quay.io/openshiftio/rhel-fabric8io-wwwopenshiftio
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-openshiftio/pull/922