### PR TITLE
Update footer to use CodeReady Toolchain

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -166,10 +166,10 @@
       </div>
       <div class="top-footer--item top-footer--item_intro">
         <p class="title uppercase">
-          Red Hat OpenShift.io
+          Red Hat CodeReady Toolchain
         </p>
         <p class="product-footer-intro_paragraph">
-          When you sign up to use OpenShift.io, you are given an OpenShift Online account with enough resources to run a basic stage and run environment, pipelines, and an Eclipse Che development workspace.
+          When you sign up to use CodeReady Toolchain, you are given an OpenShift Online account with enough resources to run a basic stage and run environment, pipelines, and an Eclipse Che development workspace.
         </p>
       </div>
       <div></div>


### PR DESCRIPTION
Changes Openshift.io to CodeReady Toolchain in the footer of the home page.