### PR TITLE
 fix(redirect): fix che redirect url to support prod-preview

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -97,7 +97,7 @@
           <!--Inserting 3% height gap--><p class="design-gap"></p>
           <p><a class="btn btn-heavy-cta btn-lg beta-submit uppercase" role="button" id="registerContent">sign up</a></p>
           <!--Inserting 3% height gap--><p class="design-gap"></p>
-          <p class="information-text">             
+          <p class="introduction-text">             
             OpenShift.io services can be used separately or together. 
             Today all are available online and some are available for download to a private OpenShift install.
             As we grow the breadth of the services we will make more of them privately deployable.
@@ -111,19 +111,22 @@
         <div class="register--content">
           <h2>Development Services on OpenShift.io</h2>
           <div class="information-text">
-            - Code with a Red Hat hosted in-browser IDE powered by Eclipse Che: 
-            <a href="" onclick="$('#registerContent').click()">Sign-up as SaaS </a> |
-            <a href="https://www.eclipse.org/che/" target="_blank">Download CodeReady Workspaces for OpenShift</a> |
-            <a href="https://developers.redhat.com/products/codeready-workspaces/" target="_blank">Download Eclipse Che for any Kubernetes</a>
-            <!--Inserting 3% height gap--><p class="design-gap"></p>
-            - Analyze your project’s dependencies using service that analyses millions of repositories using machine learning to check security vulnerabilities, licences and smart suggestion to improve your project: 
-            Use in <a href="https://che.openshift.io" target="_blank">Hosted Che</a> |
-            <a href="https://marketplace.visualstudio.com/items?itemName=redhat.fabric8-analytics" target="_blank">Add to VS Code</a> |
-            <a href="https://marketplace.eclipse.org/content/red-hat-developer-studio" target="_blank">Add to Eclipse Desktop IDE</a> 
-            <!--Inserting 3% height gap--><p class="design-gap"></p>
-            - A wizard based application creator to scaffold your microservice-based applications:
-            <br>Use as <a href="https://developers.redhat.com/launch" target="_blank">SaaS</a> |
-            <a href="https://marketplace.visualstudio.com/items?itemName=redhat.project-initializer" target="_blank">Add to VS Code</a> 
+              - Code with a Red Hat hosted in-browser IDE powered by Eclipse Che:
+              <br/>
+              <a id="registerContent2">Sign-up as SaaS </a> |
+              <a href="https://www.eclipse.org/che/" target="_blank">Download CodeReady Workspaces for OpenShift</a> |
+              <a href="https://developers.redhat.com/products/codeready-workspaces/" target="_blank">Download Eclipse Che for any Kubernetes</a>
+              <!--Inserting 3% height gap--><p class="design-gap"></p>
+              - Analyze your project’s dependencies using service that analyses millions of repositories using machine learning to check security vulnerabilities, licences and smart suggestion to improve your project: 
+              <br/>
+              <a href="https://che.openshift.io" target="_blank">Use as Hosted Che</a> |
+              <a href="https://marketplace.visualstudio.com/items?itemName=redhat.fabric8-analytics" target="_blank">Add to VS Code</a> |
+              <a href="https://marketplace.eclipse.org/content/red-hat-developer-studio" target="_blank">Add to Eclipse Desktop IDE</a> 
+              <!--Inserting 3% height gap--><p class="design-gap"></p>
+              - A wizard based application creator to scaffold your microservice-based applications:
+              <br/>
+              <a href="https://developers.redhat.com/launch" target="_blank">Use as SaaS</a> |
+              <a href="https://marketplace.visualstudio.com/items?itemName=redhat.project-initializer" target="_blank">Add to VS Code</a> 
           </div>
         </div>
         <!--2nd Section: Informative ends-->
@@ -137,9 +140,10 @@
             You can find more information about OpenShift here: <a href="https://www.openshift.com" target="_blank">https://www.openshift.com/</a>
             <!--Inserting 3% height gap--><p class="design-gap"></p>
             OpenShift is available in three ways:
-            <p>- OpenShift Dedicated: A private Kubernetes cluster fully-managed by Red Hat (it’s what we use for OpenShift.io itself).</p>
-            <p>- OpenShift Online: On-demand access to OpenShift in a Red Hat-managed Kubernetes public cloud with shared resources.</p>
-            <p>- OpenShift Container Platform: A secure Kubernetes platform on your own infrastructure.</p>
+            <p>- <b>OpenShift Dedicated:</b> A private Kubernetes cluster fully-managed by Red Hat (it’s what we use for OpenShift.io itself).</p>
+            <p>- <b>OpenShift Online:</b> On-demand access to OpenShift in a Red Hat-managed Kubernetes public cloud with shared resources.</p>
+            <p>- <b>OpenShift Container Platform:</b> A secure Kubernetes platform on your own infrastructure.</p>
+
           </div>
         </div>
         <!--3rd Section: Informative ends-->

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -25,7 +25,7 @@
       var tokenObj = JSON.parse(tokenJson);
       localStorage.setItem('auth_token', tokenObj.access_token);
       localStorage.setItem('refresh_token', tokenObj.refresh_token);
-      window.location.href = 'https://che.openshift.io';
+      window.location.href = 'https://che.' + location.hostname;
     }
   </script>
   <link rel="manifest" href="/manifest.json">

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -355,13 +355,8 @@ $(document)
     loadConfig<OpenshiftIoConfig>('www.openshift.io', (config) => {
 
       analytics.loadAnalytics(config.analyticsWriteKey);
-      $('#registerNav').click(function () {
+      $('#registerNav, #registerContent, #registerContent2').attr('href', config.waitlistUrl).click(function () {
         analytics.trackRegister();
-        window.location.href = config.waitlistUrl;
-      });
-      $('#registerContent').click(function () {
-        analytics.trackRegister();
-        window.location.href = config.waitlistUrl;
       });
     });
 

--- a/src/assets/stylesheets/_layout.less
+++ b/src/assets/stylesheets/_layout.less
@@ -162,7 +162,7 @@ body {
   margin: 0 auto 40px;
 }
 .information-text {
-  font-size: 1.514em;
+  font-size: 1.2em;
   font-weight: normal;
   font-family: Overpass, sans-serif;
   line-height: 150%;
@@ -175,5 +175,8 @@ body {
 .restrict--width--900 {
   max-width: 900px;
   margin: auto;
+}
+.register--content {
+  padding: 0 16px;
 }
 


### PR DESCRIPTION
- **index.html:** updated the redirect to che url to be dynamic based off of the current `location.hostname` such that in prod-preview we redirect to `https://che.prod-preview.openshift.io`

@abhinandan13jan mentioned that the new sign-up link wasn't working correctly. Also fixed this link to navigate the user to the sign-up page.

Added a few minor layout tweaks:
- bold list item titles
- add padding to content area for mobile
- reduce text size of secondary content
- fix a couple of links which didn't include the full text in the link

![image](https://user-images.githubusercontent.com/14068621/55750377-27315880-5a11-11e9-9b1c-6383e679d859.png)
