### PR TITLE
fix(redirect): fix another instance of che redirect to support prod-preview

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -335,7 +335,7 @@ function goToApp() {
   $("#hideLogIn").hide();
   $("#hideSignUp").hide();
   $("#loggedInUserName").show();
-  window.location.href = "https://che.openshift.io";
+  window.location.href = "https://che." + location.hostname;
 }
 
 $(window).scroll(collapseNavbar);


### PR DESCRIPTION
Updated url creation for che redirect to use `location.hostname` in order to support redirect to `che.prod-preview.openshift.io`.