### PR TITLE
fix(redirect): remove extra marketing pages and fix rewrite rules

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -63,20 +63,22 @@ http {
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;
 
-        location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
-
-        }
-        location /index.html{
-
-        }
-        location = / {
-            try_files '' /index.html;
-        }
-
         location / {
-            rewrite ^ / permanent;
+            try_files $uri $uri/ @rewrite;
+            etag off;
+            if_modified_since off;	
+            expires 1y;
         }
 
+        location @rewrite {
+            return 301 /;
+        }
+
+        gzip            on;
+        gzip_min_length 1000;
+        gzip_comp_level 9;
+        gzip_proxied    expired no-cache no-store private auth;
+        gzip_types      text/plain text/css application/javascript application/xml;
     }
 
 # Settings for a TLS enabled server.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,29 +153,29 @@ module.exports = {
       chunks: ['app'],
       chunksSortMode: 'dependency'
     }),
-    new HtmlWebpackPlugin({
-      filename: 'features.html',
-      template: 'src/app/pages/features.html',
-      chunks: ['app'],
-      chunksSortMode: 'dependency'
-    }),
-    new HtmlWebpackPlugin({
-      filename: 'get-involved.html',
-      template: 'src/app/pages/get-involved.html',
-      chunks: ['app'],
-      chunksSortMode: 'dependency'
-    }),
-    new HtmlWebpackPlugin({
-      filename: 'not-authorized.html',
-      template: 'src/app/pages/not-authorized.html',
-      chunks: ['app'],
-      chunksSortMode: 'dependency'
-    }),
-    new HtmlWebpackPlugin({
-      filename: './_openshiftio/clicktale/ctIframe.html',
-      template: 'src/app/clicktale/ctIframe.html',
-      chunks: ['clicktale']
-    }),
+    // new HtmlWebpackPlugin({
+    //   filename: 'features.html',
+    //   template: 'src/app/pages/features.html',
+    //   chunks: ['app'],
+    //   chunksSortMode: 'dependency'
+    // }),
+    // new HtmlWebpackPlugin({
+    //   filename: 'get-involved.html',
+    //   template: 'src/app/pages/get-involved.html',
+    //   chunks: ['app'],
+    //   chunksSortMode: 'dependency'
+    // }),
+    // new HtmlWebpackPlugin({
+    //   filename: 'not-authorized.html',
+    //   template: 'src/app/pages/not-authorized.html',
+    //   chunks: ['app'],
+    //   chunksSortMode: 'dependency'
+    // }),
+    // new HtmlWebpackPlugin({
+    //   filename: './_openshiftio/clicktale/ctIframe.html',
+    //   template: 'src/app/clicktale/ctIframe.html',
+    //   chunks: ['clicktale']
+    // }),
 
     new DefinePlugin({
       AUTH_API_URL: JSON.stringify(process.env.FABRIC8_WIT_API_URL),


### PR DESCRIPTION
Turns out the last update that was made worked locally but failed in prod-preview :/

- Removed the extra marketing pages from the webpack build so that they never show up in the deployed directory. Only the index.html page is present. This makes editing rules for nginx.conf easier.
- Re-instated the gzip rules that were removed.
- Updated the location rules to add a 301 rewrite so that any attempt to access a url that isn't present gets immediately routed to the root page and the URL gets updated accordingly.

eg. openshift.io/features.html => openshift.io