### PR TITLE
fix(redirect): fix container port being used in redirect instead of request port

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -71,7 +71,7 @@ http {
         }
 
         location @rewrite {
-            return 301 /;
+            return 307 $scheme://$http_host;
         }
 
         gzip            on;


### PR DESCRIPTION
Locally I was testing `localhost:8080`. It so happens that the container port is also `8080` so when a redirect happened, the correct port was being used in a local test environment. However in `prod-preview` there is no port. When nginx performed the redirect, it sent the user to `https://prod-preview.openshift.io:8080` which is incorrect.

Tested locally with container port being `8080` and published port being `9090`. Successfully redirected to `localhost:9090` where before it would fail.

Turns out that we need to ensure that the request port needs to somehow be specified so that the container port isn't used in the redirect url.

Thanks to @alexeykazakov for spotting the wrong port in the headers. He also mentioned that we should use status code `307` for the redirect instead of `301` due to aggressive browser caching of `301`.