### PR TITLE
Switch URLs to fix links to products

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -111,8 +111,8 @@
             <b>CODE - </b>Use a Kube-native IDE powered by Eclipse Che:
             <ul>
               <li><a id="registerContent2">Free sign-up for hosted Eclipse Che</a></li>
-              <li><a href="https://www.eclipse.org/che/" target="_blank">Download CodeReady Workspaces for your OpenShift</a></li>
-              <li><a href="https://developers.redhat.com/products/codeready-workspaces/" target="_blank">Download the Eclipse Che project for any Kubernetes</a></li>
+              <li><a href="https://developers.redhat.com/products/codeready-workspaces/" target="_blank">Download CodeReady Workspaces for your OpenShift</a></li>
+              <li><a href="https://www.eclipse.org/che/" target="_blank">Download the Eclipse Che project for any Kubernetes</a></li>
             </ul>
             <!--Inserting 3% height gap--><p class="design-gap"></p>
             <b>ANALYZE - </b>Find security and license issues in your code:


### PR DESCRIPTION
URLs in links to Che and CRW were swapped on the index page. This fixes it.